### PR TITLE
v2.2.1 - use an updated cmudict library

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
-import { dictionary } from 'cmu-pronouncing-dictionary';
 import extractWords from 'extractwords';
+import cmudict from "@lunarisapp/cmudict";
 
+const cmuDict = cmudict.dict();
 
 export default function syllables(input, { fallbackSyllablesFunction = null } = {}) {
     if (typeof input !== 'string') {
@@ -15,10 +16,10 @@ export default function syllables(input, { fallbackSyllablesFunction = null } = 
     let syllables = 0;
 
     for (let word of words) {
-        const pronounciation = dictionary[word] ?? '';
+        const pronunciation = cmuDict[word]?.[0] ?? [];
 
-        if (pronounciation) {
-            const stresses = pronounciation.match(/[0-2]/g) ?? [];
+        if (pronunciation.length) {
+            const stresses = pronunciation.filter((phoneme) => /[0-2]/.test(phoneme));
             syllables += stresses.length;
         } else if (fallbackSyllablesFunction) {
             const fallbackSyllablesCount = fallbackSyllablesFunction(word);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "syllables",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "Count syllables in text using the CMU Pronouncing Dictionary",
     "license": "CC0-1.0",
     "repository": "muhashi/syllables",
@@ -39,7 +39,7 @@
         "arpabet"
     ],
     "dependencies": {
-        "cmu-pronouncing-dictionary": "^3.0.0",
+        "@lunarisapp/cmudict": "^1.0.0",
         "extractwords": "^2.0.0"
     },
     "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Count syllables in text using a dictionary
 
-Counts the number of syllables in given text using the [CMU Pronouncing Dictionary](https://www.npmjs.com/package/cmu-pronouncing-dictionary), which contains over 134,000 words. This has the benefit of being much more accurate than algorithmic methods, but can fall short on less common words. Unknown words are provided a syllable count of 0.
+Counts the number of syllables in given text using the [CMU Pronouncing Dictionary](https://www.npmjs.com/package/@lunarisapp/cmudict), which contains over 134,000 words. This has the benefit of being much more accurate than algorithmic methods, but can fall short on less common words. Unknown words are provided a syllable count of 0.
 
 Alternatively, a fallback function can be used in the case a word is not in the dictionary. A function such as the [npm package that counts syllables algorithmically](https://www.npmjs.com/package/syllable) can be passed as an option.
 


### PR DESCRIPTION
[cmu-pronouncing-dictionary](https://github.com/words/cmu-pronouncing-dictionary#readme) hasn't been updated for 4 years, although the dictionary itself is being actively maintained and expanded, and got quite a few [updates](https://github.com/cmusphinx/cmudict/commits/master/) since.

The PR replaces the javascript interface with the one that has an updated dataset.